### PR TITLE
検索ワードの状態管理と具体的な検索機能の実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -74,9 +74,17 @@ class MyHomePage extends ConsumerWidget {
                       onPressed: () async {
                         final String query = queryWordController.text;
                         final List result = await searchApi(query, context);
-                        MaterialPageRoute(
-                          builder: (context) => ResultPage(result: result, query: query),
-                        );
+                        if (result.isNotEmpty) {
+                          // 結果が空でない場合のみ遷移
+                          Navigator.push(
+                            // ここでNavigator.pushを呼び出して遷移
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  ResultPage(result: result, query: query),
+                            ),
+                          );
+                        }
                       },
                       child: const Text('Search'),
                     ),
@@ -98,9 +106,7 @@ class MyHomePage extends ConsumerWidget {
       if (response.statusCode == 200) {
         return jsonDecode(response.body)['items'] as List;
       } else {
-        // ポップアップでアラートダイアログで状況をユーザーに通知する
-        throw showDialog(
-            // ignore: use_build_context_synchronously
+        showDialog(
             context: context,
             builder: (BuildContext context) {
               return AlertDialog(
@@ -109,17 +115,18 @@ class MyHomePage extends ConsumerWidget {
                 actions: <Widget>[
                   TextButton(
                     onPressed: () {
-                      Navigator.of(context).pop();
+                      Navigator.of(context).pop(); // ここでダイアログを閉じる
                     },
                     child: const Text('OK'),
                   ),
                 ],
               );
             });
+        return []; // 空のリストを返して、遷移を防ぐ
       }
     } catch (e) {
       print('エラー: $e');
-      throw e;
+      return []; // エラー時にも空のリストを返す
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,7 +75,7 @@ class MyHomePage extends ConsumerWidget {
                         final String query = queryWordController.text;
                         final List result = await searchApi(query, context);
                         MaterialPageRoute(
-                          builder: (context) => ResultPage(result: result),
+                          builder: (context) => ResultPage(result: result, query: query),
                         );
                       },
                       child: const Text('Search'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:search_github_repository/provider/query_word_provider.dart';
 
 void main() {
   runApp(const ProviderScope(child: MyApp()));
@@ -21,22 +22,19 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatefulWidget {
+class MyHomePage extends ConsumerWidget {
   const MyHomePage({super.key, required this.title});
 
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final TextEditingController queryWordController = TextEditingController();
 
-class _MyHomePageState extends State<MyHomePage> {
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
+        title: Text(title),
       ),
       body: Center(
         child: Column(
@@ -60,7 +58,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     SizedBox(
                       width: MediaQuery.of(context).size.width * 0.64,
                       child: TextFormField(
-                        controller: TextEditingController(),
+                        controller: queryWordController,
                         decoration: const InputDecoration(
                           labelText: 'Search',
                           hintText: 'Search GitHub Repository',
@@ -70,7 +68,11 @@ class _MyHomePageState extends State<MyHomePage> {
                     const SizedBox(width: 10),
                     ElevatedButton(
                       onPressed: () {
-                        setState(() {});
+                        // ボタンが押されたら、StateProviderを更新
+                        ref.read(queryWordProvider.notifier).state =
+                            queryWordController.text;
+                        // ここでAPIを叩くための関数を呼び出す
+                        searchApi(queryWordController.text);
                       },
                       child: const Text('Search'),
                     ),
@@ -78,12 +80,15 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ),
             ),
-            const SizedBox(
-              height: 10,
-            ),
+            const SizedBox(height: 10),
           ],
         ),
       ),
     );
+  }
+
+  void searchApi(String query) {
+    // ここでAPIを叩く実装を行う
+    print("API called with query: $query");
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,6 +61,8 @@ class MyHomePage extends ConsumerWidget {
                       child: TextFormField(
                         controller: queryWordController,
                         decoration: const InputDecoration(
+                          enabledBorder: InputBorder.none,
+                          focusedBorder: InputBorder.none,
                           labelText: 'Search',
                           hintText: 'Search GitHub Repository',
                         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,6 +73,9 @@ class MyHomePage extends ConsumerWidget {
                       onPressed: () async {
                         final String query = queryWordController.text;
                         final List result = await searchApi(query, context);
+                        MaterialPageRoute(
+                          builder: (context) => ResultPage(result: result),
+                        );
                       },
                       child: const Text('Search'),
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:search_github_repository/screens/result_page.dart';
 
 void main() {
   runApp(const ProviderScope(child: MyApp()));

--- a/lib/provider/query_word_provider.dart
+++ b/lib/provider/query_word_provider.dart
@@ -1,0 +1,3 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final queryWordProvider = StateProvider<String>((ref) => "");

--- a/lib/screens/detail_page.dart
+++ b/lib/screens/detail_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class DetailPage extends StatelessWidget {
+  const DetailPage({super.key, required this.repository});
+
+  final Map<String, dynamic> repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(repository['full_name']),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              repository['description'],
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 16.0),
+            Text(
+              'Language: ${repository['language']}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16.0),
+            Text(
+              'Stars: ${repository['stargazers_count']}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16.0),
+            Text(
+              'Forks: ${repository['forks_count']}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/result_page.dart
+++ b/lib/screens/result_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class ResultPage extends StatelessWidget {
-  const ResultPage({super.key, required this.result});
+  const ResultPage({super.key, required this.result, required this.query});
 
   final List result;
 
@@ -9,7 +9,7 @@ class ResultPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Search Result'),
+        title: const Text(query),
       ),
       body: ListView.builder(
         itemCount: result.length,

--- a/lib/screens/result_page.dart
+++ b/lib/screens/result_page.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class ResultPage extends StatelessWidget {
+  const ResultPage({super.key, required this.result});
+
+  final List result;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Search Result'),
+      ),
+      body: ListView.builder(
+        itemCount: result.length,
+        itemBuilder: (BuildContext context, int index) {
+          return ListTile(
+            title: Text(result[index]['full_name']),
+            subtitle: Text(result[index]['description']),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => DetailPage(
+                    repository: result[index],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/result_page.dart
+++ b/lib/screens/result_page.dart
@@ -3,13 +3,14 @@ import 'package:flutter/material.dart';
 class ResultPage extends StatelessWidget {
   const ResultPage({super.key, required this.result, required this.query});
 
+  final String query;
   final List result;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text(query),
+        title: Text(query),
       ),
       body: ListView.builder(
         itemCount: result.length,

--- a/lib/screens/result_page.dart
+++ b/lib/screens/result_page.dart
@@ -14,7 +14,8 @@ class ResultPage extends StatelessWidget {
         title: Text(query),
       ),
       body: ListView.builder(
-        itemCount: result.length,
+        //上位20件のみ表示
+        itemCount: result.length > 20 ? 20 : result.length,
         itemBuilder: (BuildContext context, int index) {
           return ListTile(
             title: Text(result[index]['full_name']),

--- a/lib/screens/result_page.dart
+++ b/lib/screens/result_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:search_github_repository/screens/detail_page.dart';
 
 class ResultPage extends StatelessWidget {
   const ResultPage({super.key, required this.result, required this.query});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,6 +70,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "0f1974eff5bbe774bf1d870e406fc6f29e3d6f1c46bd9c58e7172ff68a785d7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -139,6 +147,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: f21b32ffd26a36555e501b04f4a5dca43ed59e16343f1a30c13632b2351dfa4d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -160,6 +176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:
@@ -210,3 +234,4 @@ packages:
     version: "13.0.0"
 sdks:
   dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -83,6 +83,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -216,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:
@@ -232,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
+  flutter_riverpod: ^2.5.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
   flutter_riverpod: ^2.5.1
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## やったこと
- Riverpodを用いて検索ワードの一時保存などの状態管理を実装
- ユーザーが検索したときの一連の流れ（入力→検索ボタン→結果の表示→詳細の表示）を実装

## スクリーンショット
|検索|結果表示|詳細表示|
|-|-|-|
|<img src="https://github.com/Haruki1090/SearchGithubRepository/assets/151597393/78abcc04-2a9c-49a1-86b4-a01593ad3fac" width=300>|<img src="https://github.com/Haruki1090/SearchGithubRepository/assets/151597393/237de103-196b-4d53-aad0-cf6f5946ff13" width=300>|<img src="https://github.com/Haruki1090/SearchGithubRepository/assets/151597393/684bad0a-e0e8-4983-a87a-20bde5e9ea8b" width=300>|


## 意識したこと
- 結果全てを表示するのではなく、上位20件のみを表示するように実装した。

Closes #1 
