### PR TITLE
検索履歴をトップ画面に表示する

### DIFF
--- a/lib/components/search_history_list.dart
+++ b/lib/components/search_history_list.dart
@@ -1,0 +1,52 @@
+// ignore_for_file: use_build_context_synchronously
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:search_github_repository/provider/search_history_provider.dart';
+import 'package:search_github_repository/screens/result_page.dart';
+import 'package:search_github_repository/utils/search_api.dart';
+
+class SearchHistoryList extends ConsumerWidget {
+  final TextEditingController queryWordController;
+
+  const SearchHistoryList({super.key, required this.queryWordController});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchHistoryAsyncValue = ref.watch(searchHistoryProvider);
+
+    return searchHistoryAsyncValue.when(
+      data: (searchHistoryList) {
+        return ListView.builder(
+          itemCount: searchHistoryList.length,
+          itemBuilder: (context, index) {
+            final searchHistory = searchHistoryList[index];
+            return Card(
+              child: ListTile(
+                title: Text(searchHistory.query),
+                onTap: () async{
+                  queryWordController.text = searchHistory.query;
+                  final List result =
+                  await searchApi(searchHistory.query, context);
+                  if (result.isNotEmpty) {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ResultPage(
+                          result: result,
+                          query: searchHistory.query,
+                        ),
+                      ),
+                    );
+                  }
+                },
+              ),
+            );
+          },
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stack) => Center(child: Text('Error: $error')),
+    );
+  }
+}

--- a/lib/provider/search_history_provider.dart
+++ b/lib/provider/search_history_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:search_github_repository/models/search_history_model.dart';
+import 'package:search_github_repository/service/firestore_service.dart';
+
+final searchHistoryProvider = StreamProvider<List<SearchHistory>>((ref) {
+  return getSearchHistory();
+});

--- a/lib/service/firestore_service.dart
+++ b/lib/service/firestore_service.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:search_github_repository/models/search_history_model.dart';
 
+// 検索履歴を作成する関数
 Future<void> createSearchHistory(String query) async {
   final user = FirebaseAuth.instance.currentUser;
   if (user == null) {
@@ -21,4 +22,21 @@ Future<void> createSearchHistory(String query) async {
       .doc();
 
   await document.set(searchHistory.toJson());
+}
+
+// 検索履歴を取得する関数
+Stream<List<SearchHistory>> getSearchHistory() {
+  final user = FirebaseAuth.instance.currentUser;
+  if (user == null) {
+    return Stream.value([]);
+  }
+
+  return FirebaseFirestore.instance
+      .collection('users')
+      .doc(user.uid)
+      .collection('search_history')
+      .orderBy('createdAt', descending: true)
+      .snapshots()
+      .map((snapshot) =>
+      snapshot.docs.map((doc) => SearchHistory.fromJson(doc.data())).toList());
 }

--- a/lib/utils/search_api.dart
+++ b/lib/utils/search_api.dart
@@ -1,0 +1,38 @@
+// ignore_for_file: use_build_context_synchronously
+
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:search_github_repository/utils/loading_indicator.dart';
+
+Future<List> searchApi(String query, BuildContext context) async {
+  try {
+    showLoadingIndicator(context);
+    final response = await http.get(
+        Uri.parse('https://api.github.com/search/repositories?q=$query'));
+    Navigator.of(context).pop();
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body)['items'] as List;
+    } else {
+      showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: const Text('エラーが発生しました。再度やり直してください。'),
+              content: Text('エラーコード: ${response.statusCode}'),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('OK'),
+                ),
+              ],
+            );
+          });
+      return []; // 空のリストを返して、遷移を防ぐ
+    }
+  } catch (e) {
+    return []; // エラー時にも空のリストを返す
+  }
+}


### PR DESCRIPTION
## 実装内容
- Firebaseに保存された各アカウントの検索履歴をStreamで取得し、トップページに表示する
- ログアウトしている時は何も表示しない

Closes #13 